### PR TITLE
Create a new workflow to run cypress tests when a new pull request is made

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -1,0 +1,21 @@
+name: Cypress Test
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    types: [opened, reopened]
+
+jobs:
+  test:
+    runs-on: cypress/base:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          wait-on: http://localhost:5173
+          start: npx vite --host


### PR DESCRIPTION
Added a new workflow whenever a PR is created

**What type of PR is this?**
> /kind feature

**Any specific area of the project related to this PR?**
> /area tests

**What this PR does / why we need it**:
Runs the cypress tests whenever a new PR is created

**Which issue(s) this PR fixes**:
Now we can be sure a new PR works before merging it

Fixes [Add new workflow when pull request is created](https://github.com/falcosecurity/falco-playground/issues/14)