### PR TITLE
cleanup(worker): prevent spawning of  multiple yaml workers

### DIFF
--- a/src/components/Editor/Monaco.tsx
+++ b/src/components/Editor/Monaco.tsx
@@ -8,7 +8,6 @@ import { example1, example2, example3 } from "./examples";
 import { monaco, Uri } from "./customMocaco";
 import type { CustomError, Error } from "../Sidebar/falco_output";
 import falcoSchema from "./falcoSchema.json";
-import YamlWorker from "./yaml.worker.js?worker";
 import { useSearchParams } from "react-router-dom";
 import { message } from "antd";
 
@@ -62,11 +61,6 @@ const Monaco = ({
             },
           ],
         });
-        window.MonacoEnvironment = {
-          getWorker() {
-            return new YamlWorker();
-          },
-        };
         const localCode = localStorage.getItem("code");
         const shared = localStorage.getItem("isShared");
         const query = searchParams.get("code");

--- a/src/components/Editor/yaml.worker.js
+++ b/src/components/Editor/yaml.worker.js
@@ -1,1 +1,0 @@
-import "monaco-yaml/yaml.worker.js";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,15 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
 import monacoEditorPlugin, {
   IMonacoEditorOpts,
 } from "vite-plugin-monaco-editor";
 
 // https://vitejs.dev/config/
 
-const option: IMonacoEditorOpts = {
-  languageWorkers: [],
+const options: IMonacoEditorOpts = {
+  customWorkers: [{label:"yaml",entry:"monaco-yaml/yaml.worker.js"}],
 };
 export default defineConfig({
-  plugins: [monacoEditorPlugin.default(option), react()],
+  plugins: [monacoEditorPlugin.default(options), react()],
 });


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area frontend

**What this PR does / why we need it**: 
This PR removes the creation of multiple `yaml workers`.
*Before*
<img width="199" alt="Screenshot 2023-10-03 at 7 47 06 PM" src="https://github.com/falcosecurity/falco-playground/assets/55309324/3400c951-b22a-484d-9741-d17bfc37d058">
*After*
<img width="177" alt="Screenshot 2023-10-03 at 7 47 45 PM" src="https://github.com/falcosecurity/falco-playground/assets/55309324/e6e97f2f-13d2-443b-abe1-f0f543dfcbed">

Note: `editorWorkerService` is the base worker required for proper functioning of `yamlWorker`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
