### PR TITLE
update(workflow): fix workflow not found and remove unnecessary step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,11 +37,6 @@ jobs:
       - name: Remove Unwanted Artifacts
         run: rm -rf falco-*-wasm.tar.gz falco-*-wasm
 
-      - name: Fix falco.js export
-        run: |
-          sudo apt install -y perl
-          perl -i -p0e  "s/(if \(typeof exports === 'object' && typeof module === 'object'\))[\s\S]*/export default Module;/g" ./src/Hooks/falco.js
-
       - name: Test
         uses: cypress-io/github-action@v5
         with:
@@ -49,7 +44,7 @@ jobs:
           start: npx vite --host
 
       - name: Install and build
-        run: npm install && npm run build && cd dist && rm -rf monacoeditorwork
+        run: npm install && npm run build
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -32,11 +32,6 @@ jobs:
       - name: Remove Unwanted Artifacts
         run: rm -rf falco-*-wasm.tar.gz falco-*-wasm
 
-      - name: Fix falco.js export
-        run: |
-          sudo apt install -y perl
-          perl -i -p0e  "s/(if \(typeof exports === 'object' && typeof module === 'object'\))[\s\S]*/export default Module;/g" ./src/Hooks/falco.js
-
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import monacoEditorPlugin, {
 
 const options: IMonacoEditorOpts = {
   customWorkers: [{label:"yaml",entry:"monaco-yaml/yaml.worker.js"}],
+  languageWorkers: ["editorWorkerService"]
 };
 export default defineConfig({
   plugins: [monacoEditorPlugin.default(options), react()],


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

> /area CI

**What this PR does / why we need it**:
Right now `falco-playground` can't spawn workers because the workflow is deleting them. The workflows are present in `monacoeditorwork`. This PR solves that problem.
 https://github.com/falcosecurity/falco-playground/blob/eed876e0e8bf16ede760ab248ff26b36a5c7e7b7/.github/workflows/deploy.yaml#L51-L52
 
Also removes `Fix falco.js export` step as `falco.js` is already modularized.  
 
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
