### PR TITLE
fix(schema): add override, source, exceptions, required_plugin_versions to falcoSchema.json

### DIFF
--- a/cypress/e2e/schema-validation.cy.ts
+++ b/cypress/e2e/schema-validation.cy.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import "cypress-file-upload";
+
+// Verifies that falcoSchema.json accepts the constructs added in #3432:
+//   - required_plugin_versions top-level directive
+//   - override: grammar on rules, macros, and lists
+//   - source field on rules
+//   - exceptions field on rules
+//
+// Schema validation in Monaco is async and not directly observable via DOM,
+// so these tests confirm that importing each fixture loads the editor without
+// a JS error and without the editor remaining empty — confirming the YAML is
+// structurally accepted by the import pipeline.
+
+describe("Schema validation — override, source, exceptions, plugin versions", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get(".monaco-editor").should("exist");
+  });
+
+  it("imports a file using override, source, exceptions, and required_plugin_versions without error", () => {
+    cy.get("button:contains('Import Yaml')").should("be.visible").click();
+
+    cy.get("input[type='file']").as("fileUpload");
+    cy.fixture("override-rule.yaml").then((fileContent) => {
+      cy.get("@fileUpload").attachFile({
+        fileContent: fileContent.toString(),
+        fileName: "override-rule.yaml",
+        mimeType: "application/yaml",
+      });
+    });
+
+    cy.get(".monaco-editor")
+      .should("be.visible")
+      .then(($editor) => {
+        expect($editor.text()).not.to.be.empty;
+      });
+  });
+});

--- a/cypress/fixtures/override-rule.yaml
+++ b/cypress/fixtures/override-rule.yaml
@@ -1,0 +1,62 @@
+# Fixture: demonstrates the override grammar added in falco-schema fix (#3432).
+# All four override-able fields are exercised so the schema covers them.
+
+- required_engine_version: 26
+
+- required_plugin_versions:
+    - name: container
+      version: 0.4.0
+
+- macro: never_true
+  condition: (evt.num=0)
+
+- list: shell_binaries
+  items: [ash, bash, csh, ksh, sh, tcsh, zsh, dash]
+
+# Override a macro condition (append)
+- macro: never_true
+  condition: and (proc.name=custom_proc)
+  override:
+    condition: append
+
+# Override a list's items (append)
+- list: shell_binaries
+  items: [fish]
+  override:
+    items: append
+
+# Full rule definition using the source and exceptions fields
+- rule: Read sensitive file untrusted
+  desc: An attempt to read any sensitive file by a non-trusted program.
+  condition: open_read and sensitive_files
+  output: >
+    Sensitive file opened for reading |
+    file=%fd.name user=%user.name command=%proc.cmdline
+  priority: WARNING
+  source: syscall
+  tags: [host, container, filesystem]
+  exceptions:
+    - name: proc_name
+      fields: proc.name
+      comps: =
+      values:
+        - trusted_reader
+
+# Override a rule — only the fields being changed are required;
+# desc/condition/output/priority are intentionally absent.
+- rule: Read sensitive file untrusted
+  override:
+    enabled: replace
+  enabled: false
+
+# Override a rule condition by appending extra exclusion logic
+- rule: Read sensitive file untrusted
+  condition: and not proc.name=my_trusted_binary
+  override:
+    condition: append
+
+# Override a rule priority (replace only)
+- rule: Read sensitive file untrusted
+  priority: NOTICE
+  override:
+    priority: replace

--- a/src/components/Editor/falcoSchema.json
+++ b/src/components/Editor/falcoSchema.json
@@ -7,6 +7,9 @@
         "$ref": "#definitions/RequiredEngineVersionRef"
       },
       {
+        "$ref": "#definitions/RequiredPluginVersionsRef"
+      },
+      {
         "$ref": "#definitions/ListRef"
       },
       {
@@ -14,6 +17,9 @@
       },
       {
         "$ref": "#definitions/RuleRef"
+      },
+      {
+        "$ref": "#definitions/OverrideRuleRef"
       },
       {
         "$ref": "#definitions/AppendOnlyRuleRef"
@@ -34,6 +40,46 @@
       },
       "required": ["required_engine_version"],
       "title": "RequiredEngineVersion"
+    },
+    "RequiredPluginVersionsRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required_plugin_versions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "alternatives": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["name", "version"]
+                }
+              }
+            },
+            "required": ["name", "version"]
+          }
+        }
+      },
+      "required": ["required_plugin_versions"],
+      "title": "RequiredPluginVersions"
     },
     "ListRef": {
       "type": "object",
@@ -57,6 +103,16 @@
         },
         "append": {
           "type": "boolean"
+        },
+        "override": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "items": {
+              "type": "string",
+              "enum": ["append", "replace"]
+            }
+          }
         }
       },
       "required": ["list", "items"],
@@ -74,6 +130,16 @@
         },
         "append": {
           "type": "boolean"
+        },
+        "override": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "condition": {
+              "type": "string",
+              "enum": ["append", "replace"]
+            }
+          }
         }
       },
       "required": ["macro", "condition"],
@@ -128,6 +194,61 @@
             ]
           }
         },
+        "source": {
+          "type": "string"
+        },
+        "exceptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "fields": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "comps": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "values": {
+                "type": "array"
+              }
+            },
+            "required": ["name"]
+          }
+        },
         "warn_evttypes": {
           "type": "boolean"
         },
@@ -137,6 +258,147 @@
       },
       "required": ["rule", "desc", "condition", "output", "priority"],
       "title": "Rule"
+    },
+    "OverrideRuleRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rule": {
+          "type": "string"
+        },
+        "condition": {
+          "type": "string"
+        },
+        "desc": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "output": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "string",
+          "enum": [
+            "ALERT",
+            "EMERGENCY",
+            "NOTICE",
+            "WARNING",
+            "ERROR",
+            "DEBUG",
+            "INFO",
+            "INFORMATIONAL",
+            "CRITICAL"
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "source": {
+          "type": "string"
+        },
+        "exceptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "fields": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "comps": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "values": {
+                "type": "array"
+              }
+            },
+            "required": ["name"]
+          }
+        },
+        "warn_evttypes": {
+          "type": "boolean"
+        },
+        "skip-if-unknown-filter": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "condition": {
+              "type": "string",
+              "enum": ["append", "replace"]
+            },
+            "output": {
+              "type": "string",
+              "enum": ["append", "replace"]
+            },
+            "desc": {
+              "type": "string",
+              "enum": ["append", "replace"]
+            },
+            "priority": {
+              "type": "string",
+              "enum": ["replace"]
+            },
+            "enabled": {
+              "type": "string",
+              "enum": ["replace"]
+            },
+            "tags": {
+              "type": "string",
+              "enum": ["append", "replace"]
+            }
+          }
+        }
+      },
+      "required": ["rule", "override"],
+      "title": "OverrideRule"
     },
     "AppendOnlyRuleRef": {
       "type": "object",


### PR DESCRIPTION
## What

Fixes five gaps in `src/components/Editor/falcoSchema.json` surfaced in falcosecurity/falco#3432. The Monaco editor in falco-playground uses this schema to validate rules as you type — each missing construct causes valid Falco YAML to show spurious errors (or be silently rejected by `additionalProperties: false`).

## Why each fix matters

| # | Missing construct | Impact before this fix |
|---|---|---|
| 1 | `required_plugin_versions` | Plugin-gated rule files (e.g. k8saudit, container plugin) fail schema validation on the top-level directive |
| 2 | `override:` grammar | Any rule/macro/list using the modern override syntax is rejected; users are forced to use the deprecated `append: true` pattern |
| 3 | `source:` field on rules | Rules that explicitly declare their event source (e.g. `source: syscall`) get a false "additional property" error |
| 4 | `exceptions:` field on rules | The entire exceptions mechanism (stable since engine v8) is invisible to the editor |
| 5 | `OverrideRuleRef` variant | Override-only rules that omit `desc`/`condition`/`output`/`priority` (valid per docs) fail the `required` check |

## How

**`src/components/Editor/falcoSchema.json`** (+262 lines, 0 deletions)

1. **`RequiredPluginVersionsRef`** — new top-level `anyOf` variant accepting `{name, version, alternatives?}` objects, matching the shape used in `falcosecurity/rules` main (`- required_plugin_versions: [{name: container, version: 0.4.0}]`).

2. **`OverrideRuleRef`** — new `anyOf` variant with `required: ["rule", "override"]`. All other rule fields are optional. The `override` object validates per-field actions:
   - `condition`, `output`, `desc`, `tags` → `"append" | "replace"`
   - `priority`, `enabled` → `"replace"` only (append is not valid for these fields per Falco docs)

3. **`override` on `MacroRef`** — optional `override.condition: "append" | "replace"`. `required` unchanged because `condition` is always present alongside an override directive.

4. **`override` on `ListRef`** — optional `override.items: "append" | "replace"`.

5. **`source` + `exceptions`** added to both `RuleRef` and `OverrideRuleRef`. `exceptions` entries accept both scalar and array forms for `fields` and `comps` to match all documented exception shapes.

`AppendOnlyRuleRef` and `EnableOnlyRuleRef` are kept for backwards compatibility with the legacy `append: true` pattern.

**`cypress/fixtures/override-rule.yaml`** — new fixture exercising all five constructs: `required_plugin_versions`, macro override, list override, full rule with `source` + `exceptions`, and three override-only rule variants (enabled replace, condition append, priority replace).

**`cypress/e2e/schema-validation.cy.ts`** — new test that imports the fixture and asserts the editor loads without a JS error.

## Verification

`npm run dev`, paste the fixture YAML into the editor. Before this fix every `override:`, `source:`, `exceptions:`, and `required_plugin_versions:` block shows a red squiggly "additional property" or missing-required error. After this fix the editor is clean.

Closes falcosecurity/falco#3432

```release-note
fix(schema): falcoSchema.json now accepts override grammar, source, exceptions, and required_plugin_versions — eliminating false validation errors for valid Falco rule files.
```